### PR TITLE
Add simple web UI for recording transactions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
 from fastapi import FastAPI, Depends
+from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import Session
 from sqlalchemy import select, func
 from typing import List, Dict
+from pathlib import Path
 
 from .db import Base, engine, get_db
 from .models import Account, Transaction
@@ -38,7 +40,14 @@ def create_tx(payload: TxIn, db: Session = Depends(get_db)):
     return tx
 
 @app.get("/transactions", response_model=List[TxOut])
-def list_txs(from_: str | None = None, to: str | None = None, account_id: int | None = None, db: Session = Depends(get_db)):
+def list_txs(
+    from_: str | None = None,
+    to: str | None = None,
+    account_id: int | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    db: Session = Depends(get_db),
+):
     q = select(Transaction)
     if account_id:
         q = q.where(Transaction.account_id == account_id)
@@ -47,6 +56,7 @@ def list_txs(from_: str | None = None, to: str | None = None, account_id: int | 
     if to:
         q = q.where(Transaction.date <= to)
     q = q.order_by(Transaction.date.desc(), Transaction.id.desc())
+    q = q.limit(limit).offset(offset)
     return db.scalars(q).all()
 
 @app.get("/balances")
@@ -58,3 +68,9 @@ def balances(db: Session = Depends(get_db)) -> Dict[str, float]:
         .order_by(Account.name)
     ).all()
     return {name: float(total) for name, total in rows}
+
+app.mount(
+    "/",
+    StaticFiles(directory=Path(__file__).parent / "static", html=True),
+    name="static",
+)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 SQLAlchemy>=2
 psycopg[binary]
 pydantic
+aiofiles

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <title>Movimientos</title>
+    <style>
+        body { font-family: sans-serif; margin:0; padding:0; display:flex; flex-direction:column; height:100vh; }
+        header, footer { background:#f0f0f0; padding:0.5rem; }
+        #table-container { flex:1; overflow-y:auto; }
+        table { width:100%; border-collapse:collapse; }
+        th, td { padding:0.25rem; border-bottom:1px solid #ccc; }
+        #modal { display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.4); justify-content:center; align-items:center; }
+        #modal form { background:white; padding:1rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <button id="config-btn">Configuración</button>
+    </header>
+    <div id="table-container">
+        <table id="tx-table">
+            <thead>
+                <tr>
+                    <th>Fecha</th>
+                    <th>Concepto</th>
+                    <th>Monto</th>
+                    <th>Tipo</th>
+                    <th>Cuenta</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <footer>
+        <button id="add-income">+ Ingreso</button>
+        <button id="add-expense">+ Egreso</button>
+    </footer>
+
+    <div id="modal">
+        <form id="tx-form">
+            <h3 id="form-title"></h3>
+            <label>Fecha <input type="date" name="date" required></label><br/>
+            <label>Concepto <input type="text" name="description"></label><br/>
+            <label>Monto <input type="number" step="0.01" name="amount" required></label><br/>
+            <label>Cuenta <select name="account_id"></select></label><br/>
+            <button type="submit">Guardar</button>
+            <button type="button" id="cancel-btn">Cancelar</button>
+        </form>
+    </div>
+
+    <script src="main.js"></script>
+</body>
+</html>

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,0 +1,91 @@
+const tbody = document.querySelector('#tx-table tbody');
+const container = document.getElementById('table-container');
+let offset = 0;
+const limit = 50;
+let loading = false;
+let accounts = [];
+let accountMap = {};
+
+async function fetchAccounts() {
+    const res = await fetch('/accounts');
+    accounts = await res.json();
+    accountMap = Object.fromEntries(accounts.map(a => [a.id, a.name]));
+}
+
+function renderTx(tx) {
+    const tr = document.createElement('tr');
+    const tipo = tx.amount >= 0 ? 'Ingreso' : 'Egreso';
+    const amount = Math.abs(tx.amount).toFixed(2);
+    tr.innerHTML = `<td>${tx.date}</td><td>${tx.description}</td><td>${amount}</td><td>${tipo}</td><td>${accountMap[tx.account_id] || ''}</td>`;
+    tbody.appendChild(tr);
+}
+
+async function loadMore() {
+    if (loading) return;
+    loading = true;
+    const res = await fetch(`/transactions?limit=${limit}&offset=${offset}`);
+    const data = await res.json();
+    data.forEach(renderTx);
+    offset += data.length;
+    loading = false;
+}
+
+container.addEventListener('scroll', () => {
+    if (container.scrollTop + container.clientHeight >= container.scrollHeight - 10) {
+        loadMore();
+    }
+});
+
+function openModal(type) {
+    const modal = document.getElementById('modal');
+    const form = document.getElementById('tx-form');
+    form.reset();
+    document.getElementById('form-title').textContent = type === 'income' ? 'Nuevo Ingreso' : 'Nuevo Egreso';
+    const select = form.account_id;
+    select.innerHTML = '';
+    accounts.forEach(acc => {
+        const opt = document.createElement('option');
+        opt.value = acc.id;
+        opt.textContent = acc.name;
+        select.appendChild(opt);
+    });
+    form.dataset.type = type;
+    modal.style.display = 'flex';
+}
+
+document.getElementById('add-income').onclick = () => openModal('income');
+document.getElementById('add-expense').onclick = () => openModal('expense');
+document.getElementById('cancel-btn').onclick = () => document.getElementById('modal').style.display = 'none';
+
+document.getElementById('tx-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const data = new FormData(form);
+    let amount = parseFloat(data.get('amount'));
+    if (form.dataset.type === 'expense') amount = -Math.abs(amount);
+    else amount = Math.abs(amount);
+    const payload = {
+        date: data.get('date'),
+        description: data.get('description'),
+        amount: amount,
+        notes: '',
+        account_id: parseInt(data.get('account_id'), 10)
+    };
+    await fetch('/transactions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+    document.getElementById('modal').style.display = 'none';
+    tbody.innerHTML = '';
+    offset = 0;
+    await loadMore();
+});
+
+// config button placeholder
+ document.getElementById('config-btn').onclick = () => alert('Configuración no implementada');
+
+(async function init() {
+    await fetchAccounts();
+    await loadMore();
+})();


### PR DESCRIPTION
## Summary
- serve static web interface with scrollable transaction table and forms to add incomes or expenses
- support pagination on `/transactions` endpoint
- add `aiofiles` dependency for static file serving

## Testing
- `python -m py_compile app/main.py app/models.py app/schemas.py`
- `pip install -r app/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6898d335feb483328900c1eb6b6b4e3b