### PR TITLE
Add simple web UI for recording transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 # Helper Makefile para desarrollo y automatización
 
 APP_SVC ?= app
-DB_SVC ?= db
 DOCKER_COMPOSE ?= docker compose
 MSG ?= update
 
-.PHONY: help up down down-v start stop restart ps logs logs-db shell rebuild rebuild-v push pull prune run
+.PHONY: help up down down-v start stop restart ps logs shell rebuild rebuild-v push pull prune run
 
 help:
 	@echo "Comandos disponibles:"
@@ -19,7 +18,6 @@ help:
 	@echo ""
 	@echo "Logs y shell:"
 	@echo "  make logs      - Muestra logs de todos los contenedores"
-	@echo "  make logs-db   - Muestra logs del contenedor de base de datos"
 	@echo "  make shell     - Abre una shell bash en el contenedor principal"
 	@echo ""
 	@echo "Rebuild:"
@@ -58,11 +56,7 @@ ps:
 
 # Logs y shell
 logs:
-	-$(DOCKER_COMPOSE) logs -f || true
-
-logs-db:
-	-$(DOCKER_COMPOSE) logs -f $(DB_SVC) || true
-
+        -$(DOCKER_COMPOSE) logs -f || true
 shell:
 	$(DOCKER_COMPOSE) exec $(APP_SVC) /bin/bash
 

--- a/app/db.py
+++ b/app/db.py
@@ -2,7 +2,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, DeclarativeBase
 
 import os
-DB_DSN = os.getenv("DB_DSN")
+
+# Prefer ``DATABASE_URL`` and fallback to ``DB_DSN`` for backward compatibility
+DB_DSN = os.getenv("DATABASE_URL") or os.getenv("DB_DSN")
+if not DB_DSN:
+    raise RuntimeError("DATABASE_URL not set")
 
 engine = create_engine(DB_DSN, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,10 @@
 from sqlalchemy import Column, Integer, String, Numeric, Boolean, Date, ForeignKey, Text, func
 from sqlalchemy.orm import relationship, Mapped, mapped_column
-from .db import Base
+# Allow using the models both as part of a package or standalone module
+try:  # pragma: no cover
+    from .db import Base
+except ImportError:  # pragma: no cover
+    from db import Base
 
 class Account(Base):
     __tablename__ = "accounts"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,6 @@
 fastapi
 uvicorn[standard]
 SQLAlchemy>=2
-psycopg[binary]
+psycopg2-binary
 pydantic
+aiofiles

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <title>Movimientos</title>
+    <style>
+        body { font-family: sans-serif; margin:0; padding:0; display:flex; flex-direction:column; height:100vh; }
+        header, footer { background:#f0f0f0; padding:0.5rem; }
+        #table-container { flex:1; overflow-y:auto; }
+        table { width:100%; border-collapse:collapse; }
+        th, td { padding:0.25rem; border-bottom:1px solid #ccc; }
+        #modal { display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.4); justify-content:center; align-items:center; }
+        #modal form { background:white; padding:1rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <button id="config-btn">Configuración</button>
+    </header>
+    <div id="table-container">
+        <table id="tx-table">
+            <thead>
+                <tr>
+                    <th>Fecha</th>
+                    <th>Concepto</th>
+                    <th>Monto</th>
+                    <th>Tipo</th>
+                    <th>Cuenta</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <footer>
+        <button id="add-income">+ Ingreso</button>
+        <button id="add-expense">+ Egreso</button>
+    </footer>
+
+    <div id="modal">
+        <form id="tx-form">
+            <h3 id="form-title"></h3>
+            <label>Fecha <input type="date" name="date" required></label><br/>
+            <label>Concepto <input type="text" name="description"></label><br/>
+            <label>Monto <input type="number" step="0.01" name="amount" required></label><br/>
+            <label>Cuenta <select name="account_id"></select></label><br/>
+            <button type="submit">Guardar</button>
+            <button type="button" id="cancel-btn">Cancelar</button>
+        </form>
+    </div>
+
+    <script src="main.js"></script>
+</body>
+</html>

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,0 +1,91 @@
+const tbody = document.querySelector('#tx-table tbody');
+const container = document.getElementById('table-container');
+let offset = 0;
+const limit = 50;
+let loading = false;
+let accounts = [];
+let accountMap = {};
+
+async function fetchAccounts() {
+    const res = await fetch('/accounts');
+    accounts = await res.json();
+    accountMap = Object.fromEntries(accounts.map(a => [a.id, a.name]));
+}
+
+function renderTx(tx) {
+    const tr = document.createElement('tr');
+    const tipo = tx.amount >= 0 ? 'Ingreso' : 'Egreso';
+    const amount = Math.abs(tx.amount).toFixed(2);
+    tr.innerHTML = `<td>${tx.date}</td><td>${tx.description}</td><td>${amount}</td><td>${tipo}</td><td>${accountMap[tx.account_id] || ''}</td>`;
+    tbody.appendChild(tr);
+}
+
+async function loadMore() {
+    if (loading) return;
+    loading = true;
+    const res = await fetch(`/transactions?limit=${limit}&offset=${offset}`);
+    const data = await res.json();
+    data.forEach(renderTx);
+    offset += data.length;
+    loading = false;
+}
+
+container.addEventListener('scroll', () => {
+    if (container.scrollTop + container.clientHeight >= container.scrollHeight - 10) {
+        loadMore();
+    }
+});
+
+function openModal(type) {
+    const modal = document.getElementById('modal');
+    const form = document.getElementById('tx-form');
+    form.reset();
+    document.getElementById('form-title').textContent = type === 'income' ? 'Nuevo Ingreso' : 'Nuevo Egreso';
+    const select = form.account_id;
+    select.innerHTML = '';
+    accounts.forEach(acc => {
+        const opt = document.createElement('option');
+        opt.value = acc.id;
+        opt.textContent = acc.name;
+        select.appendChild(opt);
+    });
+    form.dataset.type = type;
+    modal.style.display = 'flex';
+}
+
+document.getElementById('add-income').onclick = () => openModal('income');
+document.getElementById('add-expense').onclick = () => openModal('expense');
+document.getElementById('cancel-btn').onclick = () => document.getElementById('modal').style.display = 'none';
+
+document.getElementById('tx-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const data = new FormData(form);
+    let amount = parseFloat(data.get('amount'));
+    if (form.dataset.type === 'expense') amount = -Math.abs(amount);
+    else amount = Math.abs(amount);
+    const payload = {
+        date: data.get('date'),
+        description: data.get('description'),
+        amount: amount,
+        notes: '',
+        account_id: parseInt(data.get('account_id'), 10)
+    };
+    await fetch('/transactions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+    document.getElementById('modal').style.display = 'none';
+    tbody.innerHTML = '';
+    offset = 0;
+    await loadMore();
+});
+
+// config button placeholder
+ document.getElementById('config-btn').onclick = () => alert('Configuración no implementada');
+
+(async function init() {
+    await fetchAccounts();
+    await loadMore();
+})();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,16 @@
 services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_USER: app
-      POSTGRES_PASSWORD: app
-      POSTGRES_DB: movdb
-    volumes:
-      - db_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U app -d movdb"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-
   app:
     build: ./app
     environment:
-      DB_DSN: postgresql+psycopg://app:app@db:5432/movdb
-    depends_on:
-      db:
-        condition: service_healthy
-    ports:
-      - "5050:8000"
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://postgres:postgres@db:5432/db_TA}
+    expose:
+      - "8000"
+    networks:
+      - net_TA
+      - nginx_net
 
-volumes:
-  db_data:
+networks:
+  net_TA:
+    external: true
+  nginx_net:
+    external: true


### PR DESCRIPTION
## Summary
- connect FastAPI app to external Postgres via `DATABASE_URL` and auto-create tables
- drop bundled Postgres service and attach app container to existing `net_TA` and `nginx_net` networks without host exposure
- switch to `psycopg2` driver and clean Makefile references to database service
- allow imports to resolve whether the app runs as part of a package or as a standalone module

## Testing
- `pip install -r app/requirements.txt`
- `python -m py_compile app/main.py app/models.py app/schemas.py app/db.py`


------
https://chatgpt.com/codex/tasks/task_e_6898d335feb483328900c1eb6b6b4e3b