### PR TITLE
Align transaction API with frontend

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -43,15 +43,23 @@ def list_accounts(db: Session = Depends(get_db)):
 
 @app.post("/transactions", response_model=TransactionOut)
 def create_tx(payload: TransactionCreate, db: Session = Depends(get_db)):
-    data = payload.dict()
-    amount = data.pop("amount")
-    kind = data.pop("kind")
-    signed = -abs(amount) if kind == "egreso" else abs(amount)
-    tx = Transaction(amount=signed, **data)
+    tx = Transaction(**payload.dict())
     db.add(tx)
     db.commit()
     db.refresh(tx)
     return tx
+
+
+@app.get("/transactions", response_model=List[TransactionOut])
+def list_transactions(limit: int = 50, offset: int = 0, db: Session = Depends(get_db)):
+    stmt = (
+        select(Transaction)
+        .order_by(Transaction.date.desc(), Transaction.id.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    rows = db.scalars(stmt).all()
+    return rows
 
 @app.get("/accounts/balances", response_model=List[AccountBalance])
 def account_balances(to_date: date | None = None, db: Session = Depends(get_db)):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 from datetime import date
 from decimal import Decimal
-from typing import Literal
+
 from config.constants import Currency
 
 class AccountIn(BaseModel):
@@ -20,7 +20,6 @@ class TransactionCreate(BaseModel):
     date: date
     description: str = ""
     amount: Decimal
-    kind: Literal["ingreso", "egreso"]
     notes: str = ""
 
 


### PR DESCRIPTION
## Summary
- Remove `kind` field from transaction creation and accept signed amount directly
- Add `/transactions` endpoint for paginated transaction listing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899273889508332b2256ee701610b54