### PR TITLE
Add account edit and delete options

### DIFF
--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -37,3 +37,29 @@ export async function createAccount(payload) {
   } catch (_) {}
   return { ok: false, error };
 }
+
+export async function updateAccount(id, payload) {
+  const res = await fetch(`/accounts/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (res.ok) return { ok: true };
+  let error = 'Error al guardar';
+  try {
+    const data = await res.json();
+    error = data.detail || error;
+  } catch (_) {}
+  return { ok: false, error };
+}
+
+export async function deleteAccount(id) {
+  const res = await fetch(`/accounts/${id}`, { method: 'DELETE' });
+  if (res.ok) return { ok: true };
+  let error = 'Error al eliminar';
+  try {
+    const data = await res.json();
+    error = data.detail || error;
+  } catch (_) {}
+  return { ok: false, error };
+}

--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -23,12 +23,18 @@ export function populateAccounts(select, accounts) {
   });
 }
 
-export function renderAccount(tbody, account) {
+export function renderAccount(tbody, account, onEdit, onDelete) {
   const tr = document.createElement('tr');
   tr.innerHTML =
     `<td>${account.name}</td>` +
     `<td>${account.currency}</td>` +
-    `<td>${Number(account.opening_balance).toFixed(2)}</td>`;
+    `<td class="text-nowrap">` +
+    `<button class="btn btn-sm btn-secondary me-2">Editar</button>` +
+    `<button class="btn btn-sm btn-danger">Eliminar</button>` +
+    `</td>`;
+  const [editBtn, delBtn] = tr.querySelectorAll('button');
+  if (onEdit) editBtn.addEventListener('click', () => onEdit(account));
+  if (onDelete) delBtn.addEventListener('click', () => onDelete(account));
   tbody.appendChild(tr);
 }
 

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -11,9 +11,6 @@
     <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#sideMenu" aria-controls="sideMenu">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="ms-auto">
-      <button id="add-account" class="btn btn-primary">Agregar cuenta</button>
-    </div>
   </header>
   <div class="offcanvas offcanvas-start" tabindex="-1" id="sideMenu" aria-labelledby="sideMenuLabel">
     <div class="offcanvas-header">
@@ -27,12 +24,13 @@
     </div>
   </div>
   <main class="container mt-3">
-    <table id="account-table" class="table table-striped">
+    <table id="account-table" class="table table-sm border border-secondary w-auto">
       <thead>
-        <tr><th>Nombre</th><th>Moneda</th><th>Saldo inicial</th></tr>
+        <tr><th>Nombre</th><th>Moneda</th><th>Acciones</th></tr>
       </thead>
       <tbody></tbody>
     </table>
+    <button id="add-account" class="btn btn-primary mt-2">Agregar cuenta</button>
   </main>
   <div class="modal fade" id="accountModal" tabindex="-1">
     <div class="modal-dialog">
@@ -43,6 +41,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body">
+            <input type="hidden" name="id">
             <div class="mb-3">
               <label class="form-label">Nombre
                 <input type="text" name="name" class="form-control" required>


### PR DESCRIPTION
## Summary
- Remove opening balance from configuration table
- Add edit and delete account actions with confirmation
- Move add-account button below compact bordered table

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6899f63965648332a886b140a38907bc