### PR TITLE
Move account color selection to modal and restyle accounts table

### DIFF
--- a/app/static/js/config.js
+++ b/app/static/js/config.js
@@ -10,6 +10,9 @@ const addBtn = document.getElementById('add-account');
 const alertBox = document.getElementById('acc-alert');
 const currencySelect = form.currency;
 const idField = form.querySelector('input[name="id"]');
+const colorInput = form.querySelector('input[name="color"]');
+const colorBtn = document.getElementById('color-btn');
+const modalTitle = modalEl.querySelector('.modal-title');
 let accounts = [];
 
 function populateCurrencies() {
@@ -27,20 +30,27 @@ addBtn.addEventListener('click', () => {
   populateCurrencies();
   idField.value = '';
   alertBox.classList.add('d-none');
+  colorInput.value = '#ffffff';
+  colorBtn.style.backgroundColor = '#ffffff';
+  modalTitle.textContent = 'Nueva cuenta';
   accModal.show();
+});
+
+colorBtn.addEventListener('click', () => colorInput.click());
+colorInput.addEventListener('input', e => {
+  colorBtn.style.backgroundColor = e.target.value;
 });
 
 form.addEventListener('submit', async e => {
   e.preventDefault();
   if (!form.reportValidity()) return;
   const data = new FormData(form);
-  const existing = accounts.find(a => a.id === parseInt(idField.value, 10));
   const payload = {
     name: data.get('name'),
     currency: data.get('currency'),
     opening_balance: parseFloat(data.get('opening_balance') || '0'),
     is_active: true,
-    color: existing ? existing.color : '#000000'
+    color: data.get('color') || '#000000'
   };
   showOverlay();
   let result;
@@ -64,7 +74,7 @@ form.addEventListener('submit', async e => {
 
 async function loadAccounts() {
   accounts = await fetchAccounts();
-  accounts.forEach(acc => renderAccount(tbody, acc, startEdit, removeAccount, changeColor));
+  accounts.forEach(acc => renderAccount(tbody, acc, startEdit, removeAccount));
 }
 
 
@@ -75,7 +85,10 @@ function startEdit(acc) {
   form.currency.value = acc.currency;
   form.opening_balance.value = acc.opening_balance;
   idField.value = acc.id;
+  colorInput.value = acc.color;
+  colorBtn.style.backgroundColor = acc.color;
   alertBox.classList.add('d-none');
+  modalTitle.textContent = 'Editar cuenta';
   accModal.show();
 }
 
@@ -89,24 +102,6 @@ async function removeAccount(acc) {
     await loadAccounts();
   } else {
     alert(result.error || 'Error al eliminar');
-  }
-}
-
-async function changeColor(acc, color) {
-  const payload = {
-    name: acc.name,
-    currency: acc.currency,
-    opening_balance: acc.opening_balance,
-    is_active: acc.is_active,
-    color
-  };
-  showOverlay();
-  const result = await updateAccount(acc.id, payload);
-  hideOverlay();
-  if (result.ok) {
-    acc.color = color;
-  } else {
-    alert(result.error || 'Error al guardar color');
   }
 }
 

--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -26,19 +26,16 @@ export function populateAccounts(select, accounts) {
   });
 }
 
-export function renderAccount(tbody, account, onEdit, onDelete, onColor) {
+export function renderAccount(tbody, account, onEdit, onDelete) {
   const tr = document.createElement('tr');
   tr.innerHTML =
     `<td>${account.name}</td>` +
     `<td>${account.currency}</td>` +
     `<td class="text-nowrap">` +
-    `<input type="color" class="form-control form-control-color p-0 border-0 me-2" value="${account.color}" title="Color">` +
     `<button class="btn btn-sm btn-outline-secondary me-2" title="Editar"><i class="bi bi-pencil"></i></button>` +
     `<button class="btn btn-sm btn-outline-danger" title="Eliminar"><i class="bi bi-x"></i></button>` +
     `</td>`;
-  const colorInput = tr.querySelector('input[type="color"]');
   const [editBtn, delBtn] = tr.querySelectorAll('button');
-  if (onColor) colorInput.addEventListener('input', e => onColor(account, e.target.value));
   if (onEdit) editBtn.addEventListener('click', () => onEdit(account));
   if (onDelete) delBtn.addEventListener('click', () => onDelete(account));
   tbody.appendChild(tr);

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -28,9 +28,13 @@
     <h2 class="mb-3">Cuentas</h2>
     <div class="w-75 mx-auto">
 
-      <table id="account-table" class="table table-striped table-bordered border-secondary rounded overflow-hidden shadow-sm">
-        <thead>
-          <tr><th>Nombre</th><th>Moneda</th><th>Acciones</th></tr>
+      <table id="account-table" class="table table-striped table-borderless mb-0 shadow-sm">
+        <thead class="table-secondary">
+          <tr>
+            <th class="text-center fw-bold">Nombre</th>
+            <th class="text-center fw-bold">Moneda</th>
+            <th class="text-center fw-bold">Acciones</th>
+          </tr>
         </thead>
         <tbody></tbody>
       </table>
@@ -61,6 +65,11 @@
               <label class="form-label">Saldo inicial
                 <input type="number" step="0.01" name="opening_balance" class="form-control" value="0">
               </label>
+            </div>
+            <div class="mb-3">
+              <label class="form-label d-block">Color</label>
+              <input type="color" name="color" class="d-none">
+              <button type="button" id="color-btn" class="btn btn-light border border-secondary rounded-pill px-4">Color</button>
             </div>
             <div id="acc-alert" class="alert d-none" role="alert"></div>
           </div>


### PR DESCRIPTION
## Summary
- Add color selector button in account modal with default white style and dynamic color updates
- Change modal title to 'Editar cuenta' when editing
- Simplify account table and restyle header without borders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a0f9990688332b9ef49fc37fea11f