### PR TITLE
Soft-delete accounts with confirmation modal

### DIFF
--- a/app/routes/accounts.py
+++ b/app/routes/accounts.py
@@ -34,8 +34,13 @@ def create_account(payload: AccountIn, db: Session = Depends(get_db)):
 
 
 @router.get("", response_model=List[AccountOut])
-def list_accounts(db: Session = Depends(get_db)):
-    rows = db.scalars(select(Account).order_by(Account.name)).all()
+def list_accounts(
+    include_inactive: bool = False, db: Session = Depends(get_db)
+):
+    stmt = select(Account).order_by(Account.name)
+    if not include_inactive:
+        stmt = stmt.where(Account.is_active == True)
+    rows = db.scalars(stmt).all()
     return rows
 
 
@@ -68,7 +73,7 @@ def delete_account(account_id: int, db: Session = Depends(get_db)):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Account not found"
         )
-    db.delete(acc)
+    acc.is_active = False
     db.commit()
     return {"ok": True}
 

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -1,5 +1,5 @@
-export async function fetchAccounts() {
-  const res = await fetch('/accounts');
+export async function fetchAccounts(includeInactive = false) {
+  const res = await fetch(`/accounts?include_inactive=${includeInactive}`);
   return res.json();
 }
 

--- a/app/static/js/config.js
+++ b/app/static/js/config.js
@@ -14,6 +14,11 @@ const colorInput = form.querySelector('input[name="color"]');
 const colorBtn = document.getElementById('color-btn');
 const modalTitle = modalEl.querySelector('.modal-title');
 let accounts = [];
+const confirmEl = document.getElementById('confirmModal');
+const confirmModal = new bootstrap.Modal(confirmEl);
+const confirmMessage = confirmEl.querySelector('#confirm-message');
+const confirmBtn = confirmEl.querySelector('#confirm-yes');
+let accountToDelete = null;
 
 function populateCurrencies() {
   currencySelect.innerHTML = '';
@@ -95,9 +100,16 @@ function startEdit(acc) {
 }
 
 async function removeAccount(acc) {
-  if (!confirm('¿Eliminar cuenta?')) return;
+  accountToDelete = acc;
+  confirmMessage.textContent = `¿Eliminar cuenta "${acc.name}"?`;
+  confirmModal.show();
+}
+
+confirmBtn.addEventListener('click', async () => {
+  if (!accountToDelete) return;
+  confirmModal.hide();
   showOverlay();
-  const result = await deleteAccount(acc.id);
+  const result = await deleteAccount(accountToDelete.id);
   hideOverlay();
   if (result.ok) {
     tbody.innerHTML = '';
@@ -105,6 +117,7 @@ async function removeAccount(acc) {
   } else {
     alert(result.error || 'Error al eliminar');
   }
-}
+  accountToDelete = null;
+});
 
 loadAccounts();

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -26,7 +26,7 @@ async function loadMore() {
 function openModal(type) {
   form.reset();
   document.getElementById('form-title').textContent = type === 'income' ? 'Nuevo Ingreso' : 'Nuevo Egreso';
-  populateAccounts(form.account_id, accounts);
+  populateAccounts(form.account_id, accounts.filter(a => a.is_active));
   form.dataset.type = type;
   alertBox.classList.add('d-none');
   const today = new Date().toISOString().split('T')[0];
@@ -85,7 +85,7 @@ form.addEventListener('submit', async e => {
 });
 
 (async function init() {
-  accounts = await fetchAccounts();
+  accounts = await fetchAccounts(true);
   accountMap = Object.fromEntries(accounts.map(a => [a.id, a]));
   await loadMore();
 })();

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -81,6 +81,24 @@
     </div>
   </div>
 
+  <div class="modal fade" id="confirmModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Confirmación</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <p id="confirm-message"></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-danger" id="confirm-yes">Eliminar</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div id="overlay" class="d-none">
     <div class="spinner-border text-primary" role="status"></div>
   </div>


### PR DESCRIPTION
## Summary
- Mark accounts as inactive instead of deleting to preserve transaction history
- Add query option to list active or all accounts
- Show Bootstrap confirmation dialog before deactivating an account

## Testing
- `python -m py_compile app/routes/accounts.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a3932162c83328f5335eacdb492ca