### PR TITLE
Add tax model and configuration UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from config.db import init_db
 from routes.accounts import router as accounts_router
 from routes.health import router as health_router
 from routes.transactions import router as transactions_router
+from routes.taxes import router as taxes_router
 
 app = FastAPI(title="Movimientos")
 
@@ -17,6 +18,7 @@ def on_startup() -> None:
 app.include_router(health_router)
 app.include_router(accounts_router)
 app.include_router(transactions_router)
+app.include_router(taxes_router)
 
 app.mount(
     "/static",

--- a/app/models.py
+++ b/app/models.py
@@ -52,3 +52,10 @@ class Transaction(Base):
     )
 
     account = relationship("Account", back_populates="transactions")
+
+
+class Tax(Base):
+    __tablename__ = "taxes"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
+    rate: Mapped[Decimal] = mapped_column(Numeric(5, 2), nullable=False)

--- a/app/routes/taxes.py
+++ b/app/routes/taxes.py
@@ -1,0 +1,60 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from config.db import get_db
+from models import Tax
+from schemas import TaxIn, TaxOut
+
+router = APIRouter(prefix="/taxes")
+
+
+@router.post("", response_model=TaxOut)
+def create_tax(payload: TaxIn, db: Session = Depends(get_db)):
+    existing = db.scalar(select(Tax).where(Tax.name == payload.name))
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Tax name already exists",
+        )
+    tax = Tax(**payload.dict())
+    db.add(tax)
+    db.commit()
+    db.refresh(tax)
+    return tax
+
+
+@router.get("", response_model=List[TaxOut])
+def list_taxes(db: Session = Depends(get_db)):
+    rows = db.scalars(select(Tax).order_by(Tax.name)).all()
+    return rows
+
+
+@router.put("/{tax_id}", response_model=TaxOut)
+def update_tax(tax_id: int, payload: TaxIn, db: Session = Depends(get_db)):
+    tax = db.get(Tax, tax_id)
+    if not tax:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tax not found")
+    existing = db.scalar(select(Tax).where(Tax.name == payload.name, Tax.id != tax_id))
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Tax name already exists",
+        )
+    for field, value in payload.dict().items():
+        setattr(tax, field, value)
+    db.commit()
+    db.refresh(tax)
+    return tax
+
+
+@router.delete("/{tax_id}")
+def delete_tax(tax_id: int, db: Session = Depends(get_db)):
+    tax = db.get(Tax, tax_id)
+    if not tax:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tax not found")
+    db.delete(tax)
+    db.commit()
+    return {"ok": True}

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -16,6 +16,17 @@ class AccountOut(AccountIn):
     class Config:
         from_attributes = True
 
+
+class TaxIn(BaseModel):
+    name: str
+    rate: Decimal
+
+
+class TaxOut(TaxIn):
+    id: int
+    class Config:
+        from_attributes = True
+
 class TransactionCreate(BaseModel):
     account_id: int
     date: date

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -63,3 +63,49 @@ export async function deleteAccount(id) {
   } catch (_) {}
   return { ok: false, error };
 }
+
+export async function fetchTaxes() {
+  const res = await fetch('/taxes');
+  return res.json();
+}
+
+export async function createTax(payload) {
+  const res = await fetch('/taxes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (res.ok) return { ok: true };
+  let error = 'Error al guardar';
+  try {
+    const data = await res.json();
+    error = data.detail || error;
+  } catch (_) {}
+  return { ok: false, error };
+}
+
+export async function updateTax(id, payload) {
+  const res = await fetch(`/taxes/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (res.ok) return { ok: true };
+  let error = 'Error al guardar';
+  try {
+    const data = await res.json();
+    error = data.detail || error;
+  } catch (_) {}
+  return { ok: false, error };
+}
+
+export async function deleteTax(id) {
+  const res = await fetch(`/taxes/${id}`, { method: 'DELETE' });
+  if (res.ok) return { ok: true };
+  let error = 'Error al eliminar';
+  try {
+    const data = await res.json();
+    error = data.detail || error;
+  } catch (_) {}
+  return { ok: false, error };
+}

--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -43,6 +43,23 @@ export function renderAccount(tbody, account, onEdit, onDelete) {
   tbody.appendChild(tr);
 }
 
+export function renderTax(tbody, tax, onEdit, onDelete) {
+  const tr = document.createElement('tr');
+  tr.classList.add('text-center');
+  const rate = Number(tax.rate).toFixed(2);
+  tr.innerHTML =
+    `<td>${tax.name}</td>` +
+    `<td>${rate}%</td>` +
+    `<td class="text-nowrap">` +
+    `<button class="btn btn-sm btn-outline-secondary me-2" title="Editar"><i class="bi bi-pencil"></i></button>` +
+    `<button class="btn btn-sm btn-outline-danger" title="Eliminar"><i class="bi bi-x"></i></button>` +
+    `</td>`;
+  const [editBtn, delBtn] = tr.querySelectorAll('button');
+  if (onEdit) editBtn.addEventListener('click', () => onEdit(tax));
+  if (onDelete) delBtn.addEventListener('click', () => onDelete(tax));
+  tbody.appendChild(tr);
+}
+
 const overlayEl = document.getElementById('overlay');
 
 export function showOverlay() {

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -25,20 +25,39 @@
     </div>
   </div>
   <main class="container mt-3">
-    <h2 class="mb-3">Cuentas</h2>
-    <div class="w-50 mx-auto">
-
-      <table id="account-table" class="table table-striped table-borderless mb-0 shadow-sm">
-        <thead class="table-secondary">
-          <tr>
-            <th class="text-center fw-bold">Nombre</th>
-            <th class="text-center fw-bold">Moneda</th>
-            <th class="text-center fw-bold">Acciones</th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-      <button id="add-account" class="btn btn-primary mt-2 shadow-sm">Agregar cuenta</button>
+    <div class="row g-4">
+      <section class="col-12 col-lg-6">
+        <div class="p-3 border rounded">
+          <h2 class="mb-3">Cuentas</h2>
+          <table id="account-table" class="table table-striped table-borderless mb-0 shadow-sm">
+            <thead class="table-secondary">
+              <tr>
+                <th class="text-center fw-bold">Nombre</th>
+                <th class="text-center fw-bold">Moneda</th>
+                <th class="text-center fw-bold">Acciones</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <button id="add-account" class="btn btn-primary mt-2 shadow-sm">Agregar cuenta</button>
+        </div>
+      </section>
+      <section class="col-12 col-lg-6">
+        <div class="p-3 border rounded">
+          <h2 class="mb-3">Impuestos</h2>
+          <table id="tax-table" class="table table-striped table-borderless mb-0 shadow-sm">
+            <thead class="table-secondary">
+              <tr>
+                <th class="text-center fw-bold">Nombre</th>
+                <th class="text-center fw-bold">Monto %</th>
+                <th class="text-center fw-bold">Acciones</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <button id="add-tax" class="btn btn-primary mt-2 shadow-sm">Agregar impuesto</button>
+        </div>
+      </section>
     </div>
   </main>
   <div class="modal fade" id="accountModal" tabindex="-1">
@@ -93,6 +112,55 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-danger" id="confirm-yes">Eliminar</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="taxModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="tax-form">
+          <div class="modal-header">
+            <h5 class="modal-title">Nuevo impuesto</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <input type="hidden" name="id">
+            <div class="mb-3">
+              <label class="form-label">Nombre
+                <input type="text" name="name" class="form-control" required>
+              </label>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Monto %
+                <input type="number" step="0.01" name="rate" class="form-control" required>
+              </label>
+            </div>
+            <div id="tax-alert" class="alert d-none" role="alert"></div>
+          </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-primary">Guardar</button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="confirmTaxModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Confirmación</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <p id="confirm-tax-message"></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-danger" id="confirm-tax-yes">Eliminar</button>
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add Tax model and CRUD API
- show taxes alongside accounts on configuration page
- implement frontend logic for creating, editing and deleting taxes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a4b0ac0a083328d032a13334f393c