### PR TITLE
Fix color picker position in account modal

### DIFF
--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -86,8 +86,10 @@
               </label>
             </div>
             <div class="mb-3">
-              <input type="color" name="color" class="d-none">
-              <button type="button" id="color-btn" class="btn btn-light border border-secondary rounded-pill px-4 fw-bold">Color</button>
+              <div class="position-relative d-inline-block">
+                <input type="color" name="color" class="position-absolute top-0 start-0 w-100 h-100 opacity-0 pe-none">
+                <button type="button" id="color-btn" class="btn btn-light border border-secondary rounded-pill px-4 fw-bold">Color</button>
+              </div>
             </div>
             <div id="acc-alert" class="alert d-none" role="alert"></div>
           </div>


### PR DESCRIPTION
## Summary
- ensure account color picker appears within the modal instead of top-left of the window

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a5a3be93883329c040d0a87c40b31