### PR TITLE
Add account totals screen with menu icons

### DIFF
--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -8,6 +8,11 @@ export async function fetchTransactions(limit, offset) {
   return res.json();
 }
 
+export async function fetchAccountBalances() {
+  const res = await fetch('/accounts/balances');
+  return res.json();
+}
+
 export async function createTransaction(payload) {
   const res = await fetch('/transactions', {
     method: 'POST',

--- a/app/static/js/totals.js
+++ b/app/static/js/totals.js
@@ -1,0 +1,27 @@
+import { fetchAccountBalances } from './api.js';
+import { showOverlay, hideOverlay } from './ui.js';
+
+const tbody = document.querySelector('#totals-table tbody');
+const refreshBtn = document.getElementById('refresh-totals');
+
+function renderTotals(data) {
+  tbody.innerHTML = '';
+  data.forEach(acc => {
+    const tr = document.createElement('tr');
+    tr.classList.add('text-center');
+    const total = Number(acc.balance).toFixed(2);
+    tr.innerHTML = `<td>${acc.name}</td><td>${total}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+async function loadTotals() {
+  showOverlay();
+  const data = await fetchAccountBalances();
+  renderTotals(data);
+  hideOverlay();
+}
+
+refreshBtn.addEventListener('click', loadTotals);
+
+loadTotals();

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -20,7 +20,9 @@
     </div>
     <div class="offcanvas-body">
       <ul class="list-unstyled">
-        <li><a href="/" class="text-decoration-none">Inicio</a></li>
+        <li class="mb-2"><a href="/" class="text-decoration-none fs-5"><i class="bi bi-house me-2"></i>Inicio</a></li>
+        <li class="mb-2"><a href="/totals.html" class="text-decoration-none fs-5"><i class="bi bi-graph-up me-2"></i>Totales</a></li>
+        <li><a href="/config.html" class="text-decoration-none fs-5"><i class="bi bi-gear me-2"></i>Configuración</a></li>
       </ul>
     </div>
   </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>Movimientos</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/static/css/layout.css">
 </head>
 <body class="d-flex flex-column min-vh-100">
@@ -23,7 +24,9 @@
     </div>
     <div class="offcanvas-body">
       <ul class="list-unstyled">
-        <li><a href="/config.html" class="text-decoration-none">Configuración</a></li>
+        <li class="mb-2"><a href="/" class="text-decoration-none fs-5"><i class="bi bi-house me-2"></i>Inicio</a></li>
+        <li class="mb-2"><a href="/totals.html" class="text-decoration-none fs-5"><i class="bi bi-graph-up me-2"></i>Totales</a></li>
+        <li><a href="/config.html" class="text-decoration-none fs-5"><i class="bi bi-gear me-2"></i>Configuración</a></li>
       </ul>
     </div>
   </div>

--- a/app/templates/totals.html
+++ b/app/templates/totals.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Totales</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/layout.css">
+</head>
+<body class="d-flex flex-column min-vh-100">
+  <header class="navbar navbar-light bg-light p-2">
+    <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#sideMenu" aria-controls="sideMenu">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+  </header>
+  <div class="offcanvas offcanvas-start" tabindex="-1" id="sideMenu" aria-labelledby="sideMenuLabel">
+    <div class="offcanvas-header">
+      <h5 id="sideMenuLabel" class="offcanvas-title">Menú</h5>
+      <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
+    </div>
+    <div class="offcanvas-body">
+      <ul class="list-unstyled">
+        <li class="mb-2"><a href="/" class="text-decoration-none fs-5"><i class="bi bi-house me-2"></i>Inicio</a></li>
+        <li class="mb-2"><a href="/totals.html" class="text-decoration-none fs-5"><i class="bi bi-graph-up me-2"></i>Totales</a></li>
+        <li><a href="/config.html" class="text-decoration-none fs-5"><i class="bi bi-gear me-2"></i>Configuración</a></li>
+      </ul>
+    </div>
+  </div>
+  <main class="container mt-3">
+    <div class="p-3 border rounded">
+      <h2 class="mb-3">Totales por cuenta</h2>
+      <table id="totals-table" class="table table-striped table-borderless mb-0 shadow-sm">
+        <thead class="table-secondary">
+          <tr class="text-center">
+            <th class="fw-bold">Nombre de cuenta</th>
+            <th class="fw-bold">Total</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <button id="refresh-totals" class="btn btn-primary mt-2 shadow-sm">Actualizar</button>
+    </div>
+  </main>
+  <div id="overlay" class="d-none">
+    <div class="spinner-border text-primary" role="status"></div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  <script type="module" src="/static/js/totals.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Totales page showing per-account totals with refresh
- Fetch account balances via new API helper
- Display menu links with larger text and icons across pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a5d79c3ac83328f0e781e8997f523