### PR TITLE
Compact transaction table without type column

### DIFF
--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -2,16 +2,25 @@ export function renderTransaction(tbody, tx, accountMap) {
   const tr = document.createElement('tr');
   const isIncome = tx.amount >= 0;
   tr.classList.add(isIncome ? 'fw-bold' : 'fst-italic');
-  const tipo = isIncome ? 'Ingreso' : 'Egreso';
   const amount = Math.abs(tx.amount).toFixed(2);
   const acc = accountMap[tx.account_id];
   const accName = acc ? acc.name : '';
   const accColor = acc ? acc.color : '';
+  const dateObj = new Date(tx.date);
+  const formattedDate = dateObj
+    .toLocaleDateString('es-ES', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric'
+    })
+    .replace('.', '');
+  const descStyle = isIncome ? '' : ' style="padding-left:2em"';
+  const amountClass = isIncome ? 'text-start' : 'text-end';
+  const amountColor = isIncome ? 'rgb(40,150,20)' : 'rgb(170,10,10)';
   tr.innerHTML =
-    `<td>${tx.date}</td>` +
-    `<td>${tx.description}</td>` +
-    `<td>${amount}</td>` +
-    `<td>${tipo}</td>` +
+    `<td>${formattedDate}</td>` +
+    `<td${descStyle}>${tx.description}</td>` +
+    `<td class="${amountClass}" style="color:${amountColor}">${amount}</td>` +
     `<td style="color:${accColor}">${accName}</td>`;
   tbody.appendChild(tr);
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -31,13 +31,12 @@
     </div>
   </div>
   <div id="table-container" class="flex-grow-1 overflow-auto">
-    <table id="tx-table" class="table table-striped mb-0 shadow-sm">
+    <table id="tx-table" class="table table-striped table-sm mb-0 shadow-sm">
       <thead>
         <tr>
           <th>Fecha</th>
           <th>Concepto</th>
           <th>Monto</th>
-          <th>Tipo</th>
           <th>Cuenta</th>
         </tr>
       </thead>


### PR DESCRIPTION
## Summary
- Compact main table and drop type column
- Format dates and highlight amounts by transaction type

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a60e758048332aa5a564887e8959a