### PR TITLE
Compact transaction table without type column

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -4,6 +4,7 @@ body {
 
 #table-container {
   overflow-y: auto;
+  padding: 1rem;
 }
 
 #overlay {
@@ -28,4 +29,10 @@ body {
   height: 2rem;
   border-radius: 50%;
   padding: 0;
+}
+
+#tx-table.table-sm td,
+#tx-table.table-sm th {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }

--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -2,17 +2,26 @@ export function renderTransaction(tbody, tx, accountMap) {
   const tr = document.createElement('tr');
   const isIncome = tx.amount >= 0;
   tr.classList.add(isIncome ? 'fw-bold' : 'fst-italic');
-  const tipo = isIncome ? 'Ingreso' : 'Egreso';
   const amount = Math.abs(tx.amount).toFixed(2);
   const acc = accountMap[tx.account_id];
   const accName = acc ? acc.name : '';
   const accColor = acc ? acc.color : '';
+  const dateObj = new Date(tx.date);
+  const formattedDate = dateObj
+    .toLocaleDateString('es-ES', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric'
+    })
+    .replace('.', '');
+  const descStyle = isIncome ? '' : ' style="padding-left:2em"';
+  const amountClass = isIncome ? 'text-start' : 'text-end';
+  const amountColor = isIncome ? 'rgb(40,150,20)' : 'rgb(170,10,10)';
   tr.innerHTML =
-    `<td>${tx.date}</td>` +
-    `<td>${tx.description}</td>` +
-    `<td>${amount}</td>` +
-    `<td>${tipo}</td>` +
-    `<td style="color:${accColor}">${accName}</td>`;
+    `<td>${formattedDate}</td>` +
+    `<td${descStyle}>${tx.description}</td>` +
+    `<td class="${amountClass}" style="color:${amountColor}">${amount}</td>` +
+    `<td class="text-center" style="color:${accColor}">${accName}</td>`;
   tbody.appendChild(tr);
 }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -31,14 +31,13 @@
     </div>
   </div>
   <div id="table-container" class="flex-grow-1 overflow-auto">
-    <table id="tx-table" class="table table-striped mb-0 shadow-sm">
+    <table id="tx-table" class="table table-striped table-sm mb-0 shadow-sm">
       <thead>
         <tr>
           <th>Fecha</th>
           <th>Concepto</th>
           <th>Monto</th>
-          <th>Tipo</th>
-          <th>Cuenta</th>
+          <th class="text-center">Cuenta</th>
         </tr>
       </thead>
       <tbody></tbody>


### PR DESCRIPTION
## Summary
- Compact main table and drop type column
- Format dates and highlight amounts by transaction type
- Add margins and taller rows, and center account column

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a60e758048332aa5a564887e8959a