### PR TITLE
Compact transaction table without type column

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -4,6 +4,30 @@ body {
 
 #table-container {
   overflow-y: auto;
+  padding: 1rem 4rem;
+  display: flex;
+  justify-content: center;
+}
+
+#tx-table {
+  width: auto;
+  table-layout: fixed;
+}
+
+#tx-table .col-date {
+  width: 13ch;
+}
+
+#tx-table .col-desc {
+  width: 40ch;
+}
+
+#tx-table .col-amount {
+  width: 24ch;
+}
+
+#tx-table .col-account {
+  width: 16ch;
 }
 
 #overlay {
@@ -28,4 +52,10 @@ body {
   height: 2rem;
   border-radius: 50%;
   padding: 0;
+}
+
+#tx-table.table-sm td,
+#tx-table.table-sm th {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }

--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -2,17 +2,26 @@ export function renderTransaction(tbody, tx, accountMap) {
   const tr = document.createElement('tr');
   const isIncome = tx.amount >= 0;
   tr.classList.add(isIncome ? 'fw-bold' : 'fst-italic');
-  const tipo = isIncome ? 'Ingreso' : 'Egreso';
   const amount = Math.abs(tx.amount).toFixed(2);
   const acc = accountMap[tx.account_id];
   const accName = acc ? acc.name : '';
   const accColor = acc ? acc.color : '';
+  const dateObj = new Date(tx.date);
+  const formattedDate = dateObj
+    .toLocaleDateString('es-ES', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric'
+    })
+    .replace('.', '');
+  const descStyle = isIncome ? '' : ' style="padding-left:2em"';
+  const amountClass = isIncome ? 'text-start' : 'text-end';
+  const amountColor = isIncome ? 'rgb(40,150,20)' : 'rgb(170,10,10)';
   tr.innerHTML =
-    `<td>${tx.date}</td>` +
-    `<td>${tx.description}</td>` +
-    `<td>${amount}</td>` +
-    `<td>${tipo}</td>` +
-    `<td style="color:${accColor}">${accName}</td>`;
+    `<td class="text-center">${formattedDate}</td>` +
+    `<td${descStyle}>${tx.description}</td>` +
+    `<td class="${amountClass}" style="color:${amountColor}">${amount}</td>` +
+    `<td class="text-center" style="color:${accColor}">${accName}</td>`;
   tbody.appendChild(tr);
 }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,13 +8,13 @@
   <link rel="stylesheet" href="/static/css/layout.css">
 </head>
 <body class="d-flex flex-column min-vh-100">
-  <header class="navbar navbar-light bg-light p-2">
-    <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#sideMenu" aria-controls="sideMenu">
+  <header class="navbar navbar-light bg-light p-2 justify-content-center position-relative">
+    <button class="navbar-toggler position-absolute start-0" type="button" data-bs-toggle="offcanvas" data-bs-target="#sideMenu" aria-controls="sideMenu">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="d-flex gap-3 ms-auto">
-      <button id="add-income" class="btn btn-success shadow-sm">+ Ingreso</button>
-      <button id="add-expense" class="btn btn-danger shadow-sm">+ Egreso</button>
+    <div class="d-flex gap-3">
+      <button id="add-income" class="btn btn-lg btn-outline-success shadow-sm"><i class="bi bi-plus-circle me-1"></i>Ingreso</button>
+      <button id="add-expense" class="btn btn-lg btn-outline-danger shadow-sm"><i class="bi bi-dash-circle me-1"></i>Egreso</button>
     </div>
   </header>
   <div class="offcanvas offcanvas-start" tabindex="-1" id="sideMenu" aria-labelledby="sideMenuLabel">
@@ -31,13 +31,18 @@
     </div>
   </div>
   <div id="table-container" class="flex-grow-1 overflow-auto">
-    <table id="tx-table" class="table table-striped mb-0 shadow-sm">
-      <thead>
+    <table id="tx-table" class="table table-striped table-sm mb-0 shadow-sm w-auto">
+      <colgroup>
+        <col class="col-date">
+        <col class="col-desc">
+        <col class="col-amount">
+        <col class="col-account">
+      </colgroup>
+      <thead class="text-center">
         <tr>
           <th>Fecha</th>
           <th>Concepto</th>
           <th>Monto</th>
-          <th>Tipo</th>
           <th>Cuenta</th>
         </tr>
       </thead>


### PR DESCRIPTION
## Summary
- Center main transaction table and assign explicit widths to each column
- Center date values and enlarge income/expense buttons with icons and softer colors

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a60e758048332aa5a564887e8959a