### PR TITLE
Fix color picker position and transaction table layout

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -5,13 +5,12 @@ body {
 #table-container {
   overflow-y: auto;
   padding: 1rem 4rem;
-  display: flex;
-  justify-content: center;
 }
 
 #tx-table {
   width: auto;
   table-layout: fixed;
+  margin: 0 auto;
 }
 
 #tx-table .col-date {

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -70,8 +70,10 @@
               </label>
             </div>
             <div class="mb-3">
-              <input type="color" name="color" class="d-none">
-              <button type="button" id="color-btn" class="btn btn-light border border-secondary rounded-pill px-4 fw-bold">Color</button>
+              <div class="position-relative d-inline-block">
+                <input type="color" name="color" class="position-absolute top-0 start-0 w-100 h-100 opacity-0 pe-none">
+                <button type="button" id="color-btn" class="btn btn-light border border-secondary rounded-pill px-4 fw-bold">Color</button>
+              </div>
             </div>
             <div id="acc-alert" class="alert d-none" role="alert"></div>
           </div>


### PR DESCRIPTION
## Summary
- Keep color picker inside account modal popup
- Restore transactions table layout and centering

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a6eff37e8833284441f189483c9c8