### PR TITLE
Fix color picker placement in account modal

### DIFF
--- a/app/static/js/config.js
+++ b/app/static/js/config.js
@@ -56,9 +56,7 @@ addBtn.addEventListener('click', () => {
   accModal.show();
 });
 
-colorBtn.addEventListener('click', () => colorInput.click());
 colorInput.addEventListener('input', e => {
-
   colorBtn.style.color = e.target.value;
 });
 

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -89,8 +89,8 @@
             </div>
             <div class="mb-3">
               <div class="position-relative d-inline-block">
-                <input type="color" name="color" class="position-absolute top-0 start-0 w-100 h-100 opacity-0 pe-none">
-                <button type="button" id="color-btn" class="btn btn-light border border-secondary rounded-pill px-4 fw-bold">Color</button>
+                <button type="button" id="color-btn" class="btn btn-light border border-secondary rounded-pill px-4 fw-bold pe-none">Color</button>
+                <input type="color" name="color" class="position-absolute top-0 start-0 w-100 h-100 opacity-0 cursor-pointer" aria-label="Color">
               </div>
             </div>
             <div id="acc-alert" class="alert d-none" role="alert"></div>


### PR DESCRIPTION
## Summary
- Overlay color input over Color button so picker opens inside the modal
- Simplify JS by relying on input events and removing manual click handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a7212e66c8332b6f7b02be94f6285