### PR TITLE
Aumentar ancho de tabla de transacciones y fijar altura de filas

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -4,30 +4,32 @@ body {
 
 #table-container {
   overflow-y: auto;
-  padding: 1rem 4rem;
-  display: flex;
-  justify-content: center;
+  padding: 1rem 2rem;
 }
 
 #tx-table {
-  width: auto;
+  width: 100%;
   table-layout: fixed;
 }
 
 #tx-table .col-date {
-  width: 13ch;
+  min-width: 13ch;
 }
 
 #tx-table .col-desc {
-  width: 40ch;
+  min-width: 40ch;
 }
 
 #tx-table .col-amount {
-  width: 24ch;
+  min-width: 24ch;
 }
 
 #tx-table .col-account {
-  width: 16ch;
+  min-width: 16ch;
+}
+
+#tx-table tbody tr {
+  height: 3rem;
 }
 
 #overlay {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -31,7 +31,7 @@
     </div>
   </div>
   <div id="table-container" class="flex-grow-1 overflow-auto">
-    <table id="tx-table" class="table table-striped table-sm mb-0 shadow-sm w-auto">
+    <table id="tx-table" class="table table-striped table-sm mb-0 shadow-sm w-100">
       <colgroup>
         <col class="col-date">
         <col class="col-desc">


### PR DESCRIPTION
## Summary
- Ensanchar la tabla de transacciones y permitir que ocupe todo el ancho disponible
- Definir anchos mínimos para cada columna y altura fija para las filas

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a86ccb0908332b7837f5424fa44c1