### PR TITLE
Duplica ancho del buscador y ajusta tabla de transacciones

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -10,22 +10,23 @@ body {
 #tx-table {
   width: 100%;
   table-layout: fixed;
+  border-top: 1px solid #eee;
 }
 
 #tx-table .col-date {
-  width: 26ch;
+  width: 15.6ch;
 }
 
 #tx-table .col-desc {
-  width: 20ch;
+  width: 59.4ch;
 }
 
 #tx-table .col-amount {
-  width: 36ch;
+  width: 19.8ch;
 }
 
 #tx-table .col-account {
-  width: 32ch;
+  width: 19.2ch;
 }
 
 #tx-table tbody tr {
@@ -66,7 +67,7 @@ body {
 }
 
 #search-box {
-  width: 20rem;
+  width: 40rem;
 }
 
 #tx-table tbody td:nth-child(3) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,7 +28,7 @@
     </div>
   </div>
   <div id="table-container" class="flex-grow-1 overflow-auto">
-    <div id="table-controls" class="d-flex align-items-center justify-content-center mb-2">
+    <div id="table-controls" class="d-flex align-items-center justify-content-center my-4">
       <button id="add-income" class="btn border border-primary text-primary action-btn d-inline-flex align-items-center"><i class="bi bi-arrow-up me-1"></i>Ingreso</button>
       <input id="search-box" class="form-control" type="search" placeholder="Buscar">
       <button id="add-expense" class="btn border border-warning text-warning action-btn d-inline-flex align-items-center"><i class="bi bi-arrow-down me-1"></i>Egreso</button>


### PR DESCRIPTION
## Summary
- duplica el ancho del buscador de transacciones a 40rem
- separa la fila de controles del título y de la tabla con margen vertical
- agrega un borde superior gris claro a la tabla de transacciones
- reduce los anchos de Fecha, Monto y Cuenta, cediendo el espacio a la columna Concepto

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689acd06db00833293d5df37d4598b2b