### PR TITLE
Centrar botones de agregar en configuración

### DIFF
--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -41,7 +41,7 @@
             </thead>
             <tbody></tbody>
           </table>
-          <button id="add-account" class="btn btn-primary mt-2 shadow-sm">Agregar cuenta</button>
+          <button id="add-account" class="btn btn-primary mt-2 shadow-sm d-block mx-auto">Agregar cuenta</button>
         </div>
       </section>
       <section class="col-12 col-lg-6">
@@ -57,7 +57,7 @@
             </thead>
             <tbody></tbody>
           </table>
-          <button id="add-tax" class="btn btn-primary mt-2 shadow-sm">Agregar impuesto</button>
+          <button id="add-tax" class="btn btn-primary mt-2 shadow-sm d-block mx-auto">Agregar impuesto</button>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Centrar botón de agregar cuenta debajo de la tabla de cuentas
- Centrar botón de agregar impuesto debajo de la tabla de impuestos

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ad28a24648332be69f0a12174214d