### PR TITLE
Uniform header bar across pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,7 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 from pathlib import Path
 
 from config.db import init_db
@@ -9,6 +11,8 @@ from routes.transactions import router as transactions_router
 from routes.taxes import router as taxes_router
 
 app = FastAPI(title="Movimientos")
+
+templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
 
 @app.on_event("startup")
@@ -26,8 +30,30 @@ app.mount(
     name="static",
 )
 
-app.mount(
-    "/",
-    StaticFiles(directory=Path(__file__).parent / "templates", html=True),
-    name="templates",
-)
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "title": "Movimientos",
+            "header_title": "Movimientos de dinero",
+        },
+    )
+
+
+@app.get("/config.html", response_class=HTMLResponse)
+async def config(request: Request):
+    return templates.TemplateResponse(
+        "config.html",
+        {"request": request, "title": "Configuración", "header_title": "Configuración"},
+    )
+
+
+@app.get("/totals.html", response_class=HTMLResponse)
+async def totals(request: Request):
+    return templates.TemplateResponse(
+        "totals.html",
+        {"request": request, "title": "Totales", "header_title": "Totales"},
+    )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>{{ title }}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/layout.css">
+</head>
+<body class="d-flex flex-column min-vh-100">
+  <header class="navbar navbar-light bg-light py-3 px-2 justify-content-center position-relative">
+    <button id="menu-button" class="navbar-toggler position-absolute" type="button" data-bs-toggle="offcanvas" data-bs-target="#sideMenu" aria-controls="sideMenu">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <h1 class="h3 m-0">{{ header_title }}</h1>
+  </header>
+  <div class="offcanvas offcanvas-start" tabindex="-1" id="sideMenu" aria-labelledby="sideMenuLabel">
+    <div class="offcanvas-header">
+      <h5 id="sideMenuLabel" class="offcanvas-title">Menú</h5>
+      <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
+    </div>
+    <div class="offcanvas-body">
+      <ul class="list-unstyled">
+        <li class="mb-2"><a href="/" class="text-decoration-none fs-5"><i class="bi bi-house me-2"></i>Inicio</a></li>
+        <li class="mb-2"><a href="/totals.html" class="text-decoration-none fs-5"><i class="bi bi-graph-up me-2"></i>Totales</a></li>
+        <li><a href="/config.html" class="text-decoration-none fs-5"><i class="bi bi-gear me-2"></i>Configuración</a></li>
+      </ul>
+    </div>
+  </div>
+  {% block content %}{% endblock %}
+  <div id="overlay" class="d-none">
+    <div class="spinner-border text-primary" role="status"></div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -1,31 +1,5 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8" />
-  <title>Configuración</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/static/css/layout.css">
-</head>
-<body class="d-flex flex-column min-vh-100">
-  <header class="navbar navbar-light bg-light p-2">
-    <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#sideMenu" aria-controls="sideMenu">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-  </header>
-  <div class="offcanvas offcanvas-start" tabindex="-1" id="sideMenu" aria-labelledby="sideMenuLabel">
-    <div class="offcanvas-header">
-      <h5 id="sideMenuLabel" class="offcanvas-title">Menú</h5>
-      <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
-    </div>
-    <div class="offcanvas-body">
-      <ul class="list-unstyled">
-        <li class="mb-2"><a href="/" class="text-decoration-none fs-5"><i class="bi bi-house me-2"></i>Inicio</a></li>
-        <li class="mb-2"><a href="/totals.html" class="text-decoration-none fs-5"><i class="bi bi-graph-up me-2"></i>Totales</a></li>
-        <li><a href="/config.html" class="text-decoration-none fs-5"><i class="bi bi-gear me-2"></i>Configuración</a></li>
-      </ul>
-    </div>
-  </div>
+{% extends "base.html" %}
+{% block content %}
   <main class="container mt-3">
     <div class="row g-4">
       <section class="col-12 col-lg-6">
@@ -101,7 +75,6 @@
       </div>
     </div>
   </div>
-
   <div class="modal fade" id="confirmModal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -119,7 +92,6 @@
       </div>
     </div>
   </div>
-
   <div class="modal fade" id="taxModal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -150,7 +122,6 @@
       </div>
     </div>
   </div>
-
   <div class="modal fade" id="confirmTaxModal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -168,12 +139,7 @@
       </div>
     </div>
   </div>
-
-  <div id="overlay" class="d-none">
-    <div class="spinner-border text-primary" role="status"></div>
-  </div>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+{% endblock %}
+{% block scripts %}
   <script type="module" src="/static/js/config.js"></script>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,32 +1,5 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8" />
-  <title>Movimientos</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/static/css/layout.css">
-</head>
-<body class="d-flex flex-column min-vh-100">
-  <header class="navbar navbar-light bg-light py-3 px-2 justify-content-center position-relative">
-    <button id="menu-button" class="navbar-toggler position-absolute" type="button" data-bs-toggle="offcanvas" data-bs-target="#sideMenu" aria-controls="sideMenu">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <h1 class="h3 m-0">Movimientos de dinero</h1>
-  </header>
-  <div class="offcanvas offcanvas-start" tabindex="-1" id="sideMenu" aria-labelledby="sideMenuLabel">
-    <div class="offcanvas-header">
-      <h5 id="sideMenuLabel" class="offcanvas-title">Menú</h5>
-      <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
-    </div>
-    <div class="offcanvas-body">
-      <ul class="list-unstyled">
-        <li class="mb-2"><a href="/" class="text-decoration-none fs-5"><i class="bi bi-house me-2"></i>Inicio</a></li>
-        <li class="mb-2"><a href="/totals.html" class="text-decoration-none fs-5"><i class="bi bi-graph-up me-2"></i>Totales</a></li>
-        <li><a href="/config.html" class="text-decoration-none fs-5"><i class="bi bi-gear me-2"></i>Configuración</a></li>
-      </ul>
-    </div>
-  </div>
+{% extends "base.html" %}
+{% block content %}
   <div id="table-container" class="flex-grow-1 overflow-auto">
     <div id="table-controls" class="d-flex align-items-center justify-content-center my-4">
       <button id="add-income" class="btn border border-primary text-primary action-btn d-inline-flex align-items-center"><i class="bi bi-arrow-up me-1"></i>Ingreso</button>
@@ -90,12 +63,7 @@
       </div>
     </div>
   </div>
-
-  <div id="overlay" class="d-none">
-    <div class="spinner-border text-primary" role="status"></div>
-  </div>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+{% endblock %}
+{% block scripts %}
   <script type="module" src="/static/js/main.js"></script>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/totals.html
+++ b/app/templates/totals.html
@@ -1,31 +1,5 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8" />
-  <title>Totales</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/static/css/layout.css">
-</head>
-<body class="d-flex flex-column min-vh-100">
-  <header class="navbar navbar-light bg-light p-2">
-    <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#sideMenu" aria-controls="sideMenu">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-  </header>
-  <div class="offcanvas offcanvas-start" tabindex="-1" id="sideMenu" aria-labelledby="sideMenuLabel">
-    <div class="offcanvas-header">
-      <h5 id="sideMenuLabel" class="offcanvas-title">Menú</h5>
-      <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
-    </div>
-    <div class="offcanvas-body">
-      <ul class="list-unstyled">
-        <li class="mb-2"><a href="/" class="text-decoration-none fs-5"><i class="bi bi-house me-2"></i>Inicio</a></li>
-        <li class="mb-2"><a href="/totals.html" class="text-decoration-none fs-5"><i class="bi bi-graph-up me-2"></i>Totales</a></li>
-        <li><a href="/config.html" class="text-decoration-none fs-5"><i class="bi bi-gear me-2"></i>Configuración</a></li>
-      </ul>
-    </div>
-  </div>
+{% extends "base.html" %}
+{% block content %}
   <main class="container mt-3">
     <div class="p-3 border rounded">
       <h2 class="mb-3">Totales por cuenta</h2>
@@ -43,10 +17,7 @@
       </table>
     </div>
   </main>
-  <div id="overlay" class="d-none">
-    <div class="spinner-border text-primary" role="status"></div>
-  </div>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+{% endblock %}
+{% block scripts %}
   <script type="module" src="/static/js/totals.js"></script>
-</body>
-</html>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ SQLAlchemy>=2
 psycopg2-binary
 pydantic
 aiofiles
+jinja2


### PR DESCRIPTION
## Summary
- Introduce base template with shared navigation and overlay
- Render HTML with Jinja2 to reuse consistent header
- Apply base layout to index, config, and totals pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ad5e5bde083328be6dd4c68cdbfe6