### PR TITLE
feat: display currency symbols

### DIFF
--- a/app/config/constants.py
+++ b/app/config/constants.py
@@ -1,5 +1,12 @@
 from enum import Enum
 
+
 class Currency(str, Enum):
     ARS = "ARS"
     USD = "USD"
+
+
+CURRENCY_SYMBOLS = {
+    Currency.ARS: "$",
+    Currency.USD: "u$s",
+}

--- a/app/static/js/constants.js
+++ b/app/static/js/constants.js
@@ -1,1 +1,6 @@
-export const CURRENCIES = ['ARS', 'USD'];
+export const CURRENCY_SYMBOLS = {
+  ARS: '$',
+  USD: 'u$s'
+};
+
+export const CURRENCIES = Object.keys(CURRENCY_SYMBOLS);

--- a/app/static/js/totals.js
+++ b/app/static/js/totals.js
@@ -1,5 +1,6 @@
 import { fetchAccountBalances } from './api.js';
 import { showOverlay, hideOverlay } from './ui.js';
+import { CURRENCY_SYMBOLS } from './constants.js';
 
 const tbody = document.querySelector('#totals-table tbody');
 const refreshBtn = document.getElementById('refresh-totals');
@@ -14,7 +15,8 @@ function renderTotals(data) {
     nameTd.textContent = acc.name;
     nameTd.style.color = acc.color;
     const totalTd = document.createElement('td');
-    totalTd.textContent = total;
+    const symbol = CURRENCY_SYMBOLS[acc.currency] || '';
+    totalTd.textContent = `${symbol} ${total}`;
     tr.appendChild(nameTd);
     tr.appendChild(totalTd);
     tbody.appendChild(tr);

--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -1,3 +1,5 @@
+import { CURRENCY_SYMBOLS } from './constants.js';
+
 export function renderTransaction(tbody, tx, accountMap) {
   const tr = document.createElement('tr');
   const isIncome = tx.amount >= 0;
@@ -5,6 +7,8 @@ export function renderTransaction(tbody, tx, accountMap) {
   const acc = accountMap[tx.account_id];
   const accName = acc ? acc.name : '';
   const accColor = acc ? acc.color : '';
+  const currency = acc ? acc.currency : null;
+  const symbol = currency ? CURRENCY_SYMBOLS[currency] || '' : '';
   const dateObj = new Date(tx.date);
   const formattedDate = dateObj
     .toLocaleDateString('es-ES', {
@@ -20,7 +24,7 @@ export function renderTransaction(tbody, tx, accountMap) {
   tr.innerHTML =
     `<td class="text-center">${formattedDate}</td>` +
     `<td class="${descClass}"${descStyle}>${tx.description}</td>` +
-    `<td class="${amountClass}" style="color:${amountColor}">${amount}</td>` +
+    `<td class="${amountClass}" style="color:${amountColor}">${symbol} ${amount}</td>` +
     `<td class="text-center" style="color:${accColor}">${accName}</td>`;
   tbody.appendChild(tr);
 }


### PR DESCRIPTION
## Summary
- map currencies to their symbols
- show currency symbol for transactions and account totals

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b41803bc08332a8261e9b77d0a5cf