### PR TITLE
Adjust transaction table styling

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -11,6 +11,9 @@ body {
   width: 100%;
   table-layout: fixed;
   border-top: 1px solid #eee;
+  font-size: calc(1rem + 2pt);
+  --bs-table-striped-bg: #e6f7ff;
+  --bs-table-bg: #ffffff;
 }
 
 #tx-table .col-date {
@@ -34,12 +37,12 @@ body {
 }
 
 #tx-table thead {
-  background-color: #b7e4b2;
+  background-color: #d3d3d3;
 }
 
 #tx-table thead th {
   text-transform: uppercase;
-  font-size: 1.1rem;
+  font-size: calc(1.1rem + 2pt);
 }
 
 #tx-table th.sortable {
@@ -89,7 +92,7 @@ body {
 }
 
 #tx-table tbody td:nth-child(3) {
-  font-size: 1.1rem;
+  font-size: calc(1.1rem + 2pt);
 }
 
 #overlay {


### PR DESCRIPTION
## Summary
- enlarge transaction table fonts by 2pt
- add alternating blue/white row stripes and grey header

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4c9b62d08332a0e1a3d655a1b693