### PR TITLE
feat: gray header for transaction table

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -41,7 +41,7 @@ body {
 }
 
 #tx-table thead {
-  background-color: #d3d3d3;
+  --bs-table-bg: #e9ecef;
 }
 
 #tx-table thead th {


### PR DESCRIPTION
## Summary
- ensure transaction table header uses gray background by overriding table background variable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b5777719c8332a7a1c954db16d931