### PR TITLE
Default transaction date to current day

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -67,6 +67,7 @@ function openModal(type) {
   alertBox.classList.add('d-none');
   const today = new Date().toISOString().split('T')[0];
   form.date.max = today;
+  form.date.value = today;
   txModal.show();
 }
 


### PR DESCRIPTION
## Summary
- Set transaction modal's date input to today's date by default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b5c49d6888332984e968b19700e76