### PR TITLE
Remove 'Menú' heading and add footer logo to side menu

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -18,17 +18,17 @@
       <img src="/static/images/TA_logo_sqr.png" alt="Logo">
     </a>
   </header>
-  <div class="offcanvas offcanvas-start" tabindex="-1" id="sideMenu" aria-labelledby="sideMenuLabel">
-    <div class="offcanvas-header">
-      <h5 id="sideMenuLabel" class="offcanvas-title">Menú</h5>
+  <div class="offcanvas offcanvas-start" tabindex="-1" id="sideMenu" aria-label="Side menu">
+    <div class="offcanvas-header justify-content-end">
       <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
     </div>
-    <div class="offcanvas-body">
+    <div class="offcanvas-body d-flex flex-column">
       <ul class="list-unstyled">
         <li class="mb-2"><a href="/" class="text-decoration-none fs-5"><i class="bi bi-house me-2"></i>Inicio</a></li>
         <li class="mb-2"><a href="/totals.html" class="text-decoration-none fs-5"><i class="bi bi-graph-up me-2"></i>Totales</a></li>
         <li><a href="/config.html" class="text-decoration-none fs-5"><i class="bi bi-gear me-2"></i>Configuración</a></li>
       </ul>
+      <img src="/static/images/TA_logo_long.png" alt="TransArgentina logo" class="img-fluid mt-auto mx-auto">
     </div>
   </div>
   {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- remove "Menú" label from side menu header
- show long logo at bottom of offcanvas menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b5c8d739483329fef2e132f319ef5