### PR TITLE
Associate taxes to accounts in configuration modal

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -14,11 +14,21 @@ from sqlalchemy import (
     Enum as SqlEnum,
     Index,
     CheckConstraint,
+    Table,
+    Column,
 )
 
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from config.db import Base
 from config.constants import Currency
+
+
+account_tax_table = Table(
+    "account_taxes",
+    Base.metadata,
+    Column("account_id", ForeignKey("accounts.id"), primary_key=True),
+    Column("tax_id", ForeignKey("taxes.id"), primary_key=True),
+)
 
 class Account(Base):
     __tablename__ = "accounts"
@@ -33,6 +43,7 @@ class Account(Base):
     )
 
     transactions = relationship("Transaction", back_populates="account")
+    taxes = relationship("Tax", secondary=account_tax_table, back_populates="accounts")
 
 
 class Transaction(Base):
@@ -59,3 +70,4 @@ class Tax(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
     rate: Mapped[Decimal] = mapped_column(Numeric(5, 2), nullable=False)
+    accounts = relationship("Account", secondary=account_tax_table, back_populates="taxes")

--- a/app/routes/accounts.py
+++ b/app/routes/accounts.py
@@ -6,13 +6,15 @@ from sqlalchemy import and_, bindparam, func, select
 from sqlalchemy.orm import Session
 
 from config.db import get_db
-from models import Account, Transaction
+from models import Account, Transaction, Tax
 from schemas import (
     AccountBalance,
     AccountIn,
     AccountOut,
     BalanceOut,
     TransactionWithBalance,
+    AccountTaxUpdate,
+    TaxOut,
 )
 
 router = APIRouter(prefix="/accounts")
@@ -76,6 +78,30 @@ def delete_account(account_id: int, db: Session = Depends(get_db)):
     acc.is_active = False
     db.commit()
     return {"ok": True}
+
+
+@router.get("/{account_id}/taxes", response_model=List[TaxOut])
+def get_account_taxes(account_id: int, db: Session = Depends(get_db)):
+    acc = db.get(Account, account_id)
+    if not acc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Account not found"
+        )
+    return acc.taxes
+
+
+@router.put("/{account_id}/taxes", response_model=List[TaxOut])
+def set_account_taxes(account_id: int, payload: AccountTaxUpdate, db: Session = Depends(get_db)):
+    acc = db.get(Account, account_id)
+    if not acc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Account not found"
+        )
+    taxes = db.scalars(select(Tax).where(Tax.id.in_(payload.tax_ids))).all()
+    acc.taxes = taxes
+    db.commit()
+    db.refresh(acc)
+    return acc.taxes
 
 
 @router.get("/balances", response_model=List[AccountBalance])

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from datetime import date
 from decimal import Decimal
+from typing import List
 
 from config.constants import Currency
 
@@ -26,6 +27,10 @@ class TaxOut(TaxIn):
     id: int
     class Config:
         from_attributes = True
+
+
+class AccountTaxUpdate(BaseModel):
+    tax_ids: List[int]
 
 class TransactionCreate(BaseModel):
     account_id: int

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -34,7 +34,10 @@ export async function createAccount(payload) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
-  if (res.ok) return { ok: true };
+  if (res.ok) {
+    const account = await res.json();
+    return { ok: true, account };
+  }
   let error = 'Error al guardar';
   try {
     const data = await res.json();
@@ -49,7 +52,10 @@ export async function updateAccount(id, payload) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
-  if (res.ok) return { ok: true };
+  if (res.ok) {
+    const account = await res.json();
+    return { ok: true, account };
+  }
   let error = 'Error al guardar';
   try {
     const data = await res.json();
@@ -108,6 +114,26 @@ export async function deleteTax(id) {
   const res = await fetch(`/taxes/${id}`, { method: 'DELETE' });
   if (res.ok) return { ok: true };
   let error = 'Error al eliminar';
+  try {
+    const data = await res.json();
+    error = data.detail || error;
+  } catch (_) {}
+  return { ok: false, error };
+}
+
+export async function fetchAccountTaxes(id) {
+  const res = await fetch(`/accounts/${id}/taxes`);
+  return res.json();
+}
+
+export async function setAccountTaxes(id, taxIds) {
+  const res = await fetch(`/accounts/${id}/taxes`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tax_ids: taxIds })
+  });
+  if (res.ok) return { ok: true };
+  let error = 'Error al guardar';
   try {
     const data = await res.json();
     error = data.detail || error;

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -50,26 +50,37 @@
           </div>
           <div class="modal-body">
             <input type="hidden" name="id">
-            <div class="mb-3">
-              <label class="form-label">Nombre
-                <input type="text" name="name" class="form-control" required>
-              </label>
+            <div class="row">
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label class="form-label">Nombre
+                    <input type="text" name="name" class="form-control" required>
+                  </label>
+                </div>
+                <div class="mb-3">
+                  <label class="form-label">Moneda
+                    <select name="currency" class="form-select" required></select>
+                  </label>
+                </div>
+                <div class="mb-3">
+                  <label class="form-label">Saldo inicial
+                    <input type="number" step="0.01" name="opening_balance" class="form-control" value="0">
+                  </label>
+                </div>
+                <div class="mb-3 position-relative">
+                  <button type="button" id="color-btn" class="btn btn-light border border-secondary rounded-pill px-4 fw-bold">Color</button>
+                  <input type="color" name="color" id="color-input" class="position-fixed opacity-0" style="left: -9999px;" aria-label="Color">
+                </div>
+                <div id="acc-alert" class="alert d-none" role="alert"></div>
+              </div>
+              <div class="col-md-6">
+                <div class="border rounded p-2">
+                  <h6>Asociar impuesto</h6>
+                  <div id="tax-assoc-list" class="mt-2"></div>
+                  <button type="button" id="assoc-tax-btn" class="btn mt-2 text-dark" style="background-color:#f8c2dc;">Asociar</button>
+                </div>
+              </div>
             </div>
-            <div class="mb-3">
-              <label class="form-label">Moneda
-                <select name="currency" class="form-select" required></select>
-              </label>
-            </div>
-            <div class="mb-3">
-              <label class="form-label">Saldo inicial
-                <input type="number" step="0.01" name="opening_balance" class="form-control" value="0">
-              </label>
-            </div>
-            <div class="mb-3 position-relative">
-              <button type="button" id="color-btn" class="btn btn-light border border-secondary rounded-pill px-4 fw-bold">Color</button>
-              <input type="color" name="color" id="color-input" class="position-fixed opacity-0" style="left: -9999px;" aria-label="Color">
-            </div>
-            <div id="acc-alert" class="alert d-none" role="alert"></div>
           </div>
           <div class="modal-footer">
             <button type="submit" class="btn btn-primary">Guardar</button>


### PR DESCRIPTION
## Summary
- allow linking taxes to accounts through new association table and API endpoints
- add tax selection panel with checkboxes to account modal
- wire up front-end to save associated taxes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b6559d1588332aa6feaab2c61ba4a